### PR TITLE
nvmm: stub driver working within whole NVMM codebase

### DIFF
--- a/build/jam/packages/Haiku
+++ b/build/jam/packages/Haiku
@@ -83,6 +83,7 @@ AddDriversToPackage graphics		: $(SYSTEM_ADD_ONS_DRIVERS_GRAPHICS) ;
 AddDriversToPackage input			: ps2_hid usb_hid wacom ;
 AddDriversToPackage misc			: <driver>poke <driver>mem ;
 AddDriversToPackage net				: $(SYSTEM_ADD_ONS_DRIVERS_NET) ;
+AddDriversToPackage nvmm			: nvmm@x86_64 ;
 AddDriversToPackage ports			: pc_serial usb_serial ;
 
 # kernel

--- a/headers/private/kernel/arch/x86/64/cpu.h
+++ b/headers/private/kernel/arch/x86/64/cpu.h
@@ -5,9 +5,7 @@
 #ifndef _KERNEL_ARCH_X86_64_CPU_H
 #define _KERNEL_ARCH_X86_64_CPU_H
 
-#ifdef __cplusplus
 #include <arch_thread_types.h>
-#endif
 
 
 extern uint16 gFPUControlDefault;

--- a/headers/private/kernel/arch/x86/64/cpu.h
+++ b/headers/private/kernel/arch/x86/64/cpu.h
@@ -5,8 +5,9 @@
 #ifndef _KERNEL_ARCH_X86_64_CPU_H
 #define _KERNEL_ARCH_X86_64_CPU_H
 
-
+#ifdef __cplusplus
 #include <arch_thread_types.h>
+#endif
 
 
 extern uint16 gFPUControlDefault;
@@ -29,6 +30,7 @@ x86_write_msr(uint32_t msr, uint64_t value)
 }
 
 
+#ifdef __cplusplus
 static inline void
 x86_context_switch(arch_thread* oldState, arch_thread* newState)
 {
@@ -51,6 +53,7 @@ x86_context_switch(arch_thread* oldState, arch_thread* newState)
 	asm volatile("ldmxcsr %0" : : "m" (gFPUMXCSRDefault));
 	asm volatile("fldcw %0" : : "m" (gFPUControlDefault));
 }
+#endif
 
 
 static inline void

--- a/headers/private/kernel/arch/x86/64/descriptors.h
+++ b/headers/private/kernel/arch/x86/64/descriptors.h
@@ -43,6 +43,11 @@ struct segment_descriptor {
 	uint32 base1 : 8;
 } _PACKED;
 
+
+#ifndef __cplusplus
+typedef struct segment_descriptor segment_descriptor;
+#endif
+
 struct tss {
 	uint32 _reserved1;
 	uint64 sp0;

--- a/headers/private/kernel/arch/x86/64/iframe.h
+++ b/headers/private/kernel/arch/x86/64/iframe.h
@@ -43,6 +43,12 @@ struct iframe {
 	};
 } _PACKED;
 
+
+#ifndef __cplusplus
+typedef struct iframe iframe;
+#endif
+
+
 #define IFRAME_IS_USER(f)	(((f)->cs & DPL_USER) == DPL_USER)
 
 

--- a/headers/private/kernel/arch/x86/arch_cpu.h
+++ b/headers/private/kernel/arch/x86/arch_cpu.h
@@ -15,7 +15,15 @@
 
 #include <module.h>
 
+#ifdef __cplusplus
 #include <arch_thread_types.h>
+#else
+#ifdef __x86_64__
+#	include <arch/x86/64/iframe.h>
+#else
+#	include <arch/x86/32/iframe.h>
+#endif // __x86_64__
+#endif // __cplusplus
 
 #include <arch/x86/arch_altcodepatch.h>
 #include <arch/x86/arch_cpuasm.h>

--- a/headers/private/kernel/arch/x86/arch_cpu.h
+++ b/headers/private/kernel/arch/x86/arch_cpu.h
@@ -15,15 +15,7 @@
 
 #include <module.h>
 
-#ifdef __cplusplus
 #include <arch_thread_types.h>
-#else
-#ifdef __x86_64__
-#	include <arch/x86/64/iframe.h>
-#else
-#	include <arch/x86/32/iframe.h>
-#endif // __x86_64__
-#endif // __cplusplus
 
 #include <arch/x86/arch_altcodepatch.h>
 #include <arch/x86/arch_cpuasm.h>

--- a/headers/private/kernel/arch/x86/arch_thread_types.h
+++ b/headers/private/kernel/arch/x86/arch_thread_types.h
@@ -18,6 +18,7 @@
 #endif
 
 
+#ifdef __cplusplus
 namespace BKernel {
     struct Thread;
 }
@@ -104,5 +105,7 @@ arch_thread::GetFramePointer() const
 
 
 #endif	// __x86_64__
+
+#endif // __cplusplus
 
 #endif	// _KERNEL_ARCH_x86_THREAD_TYPES_H

--- a/headers/private/kernel/arch/x86/descriptors.h
+++ b/headers/private/kernel/arch/x86/descriptors.h
@@ -22,6 +22,11 @@
 struct kernel_args;
 
 
+#ifndef __cplusplus
+typedef struct kernel_args kernel_args;
+#endif
+
+
 enum descriptor_types {
 	// segment types
 	DT_CODE_EXECUTE_ONLY = 0x8,

--- a/src/add-ons/kernel/drivers/Jamfile
+++ b/src/add-ons/kernel/drivers/Jamfile
@@ -13,6 +13,7 @@ SubInclude HAIKU_TOP src add-ons kernel drivers graphics ;
 SubInclude HAIKU_TOP src add-ons kernel drivers midi ;
 SubInclude HAIKU_TOP src add-ons kernel drivers misc ;
 SubInclude HAIKU_TOP src add-ons kernel drivers network ;
+SubInclude HAIKU_TOP src add-ons kernel drivers nvmm ;
 SubInclude HAIKU_TOP src add-ons kernel drivers ports ;
 SubInclude HAIKU_TOP src add-ons kernel drivers power ;
 SubInclude HAIKU_TOP src add-ons kernel drivers pty ;

--- a/src/add-ons/kernel/drivers/nvmm/Jamfile
+++ b/src/add-ons/kernel/drivers/nvmm/Jamfile
@@ -1,0 +1,12 @@
+SubDir HAIKU_TOP src add-ons kernel drivers nvmm ;
+
+UsePrivateKernelHeaders ;
+UsePrivateHeaders kernel ;
+
+SEARCH_SOURCE += [ FDirName $(SUBDIR) x86 ] ;
+
+KernelAddon nvmm :
+	nvmm.c
+	nvmm_haiku.cpp
+	nvmm_x86_vmx.c
+;

--- a/src/add-ons/kernel/drivers/nvmm/Jamfile
+++ b/src/add-ons/kernel/drivers/nvmm/Jamfile
@@ -9,4 +9,5 @@ KernelAddon nvmm :
 	nvmm.c
 	nvmm_haiku.cpp
 	nvmm_x86_vmx.c
+	nvmm_x86_svm.c
 ;

--- a/src/add-ons/kernel/drivers/nvmm/nvmm.c
+++ b/src/add-ons/kernel/drivers/nvmm/nvmm.c
@@ -43,9 +43,7 @@ volatile unsigned int nmachines __cacheline_aligned;
 
 static const struct nvmm_impl *nvmm_impl_list[] = {
 #if defined(__x86_64__)
-#ifndef __HAIKU__
 	&nvmm_x86_svm,	/* x86 AMD SVM */
-#endif
 	&nvmm_x86_vmx	/* x86 Intel VMX */
 #endif
 };

--- a/src/add-ons/kernel/drivers/nvmm/nvmm.c
+++ b/src/add-ons/kernel/drivers/nvmm/nvmm.c
@@ -26,11 +26,13 @@
  * SUCH DAMAGE.
  */
 
+#ifndef __HAIKU__
 #include <sys/param.h>
 #include <sys/systm.h>
 
 #include <sys/kernel.h>
 #include <sys/mman.h>
+#endif
 
 #include "nvmm.h"
 #include "nvmm_internal.h"
@@ -41,7 +43,9 @@ volatile unsigned int nmachines __cacheline_aligned;
 
 static const struct nvmm_impl *nvmm_impl_list[] = {
 #if defined(__x86_64__)
+#ifndef __HAIKU__
 	&nvmm_x86_svm,	/* x86 AMD SVM */
+#endif
 	&nvmm_x86_vmx	/* x86 Intel VMX */
 #endif
 };
@@ -51,7 +55,7 @@ const struct nvmm_impl *nvmm_impl __read_mostly = NULL;
 struct nvmm_owner nvmm_root_owner;
 
 /* -------------------------------------------------------------------------- */
-
+#if 0
 static int
 nvmm_machine_alloc(struct nvmm_machine **ret)
 {
@@ -121,9 +125,11 @@ nvmm_machine_put(struct nvmm_machine *mach)
 {
 	os_rwl_unlock(&mach->lock);
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static int
 nvmm_vcpu_alloc(struct nvmm_machine *mach, nvmm_cpuid_t cpuid,
     struct nvmm_cpu **ret)
@@ -190,9 +196,11 @@ nvmm_vcpu_put(struct nvmm_cpu *vcpu)
 {
 	os_mtx_unlock(&vcpu->lock);
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 void
 nvmm_kill_machines(struct nvmm_owner *owner)
 {
@@ -235,9 +243,11 @@ nvmm_kill_machines(struct nvmm_owner *owner)
 		os_rwl_unlock(&mach->lock);
 	}
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static int
 nvmm_capability(struct nvmm_owner *owner, struct nvmm_ioc_capability *args)
 {
@@ -620,9 +630,11 @@ out:
 	nvmm_machine_put(mach);
 	return error;
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static os_vmobj_t *
 nvmm_hmapping_getvmobj(struct nvmm_machine *mach, uintptr_t hva, size_t size,
    size_t *off)
@@ -787,9 +799,11 @@ nvmm_hva_unmap(struct nvmm_owner *owner, struct nvmm_ioc_hva_unmap *args)
 	nvmm_machine_put(mach);
 	return error;
 }
+#endif // 0
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static int
 nvmm_gpa_map(struct nvmm_owner *owner, struct nvmm_ioc_gpa_map *args)
 {
@@ -898,9 +912,11 @@ out:
 	nvmm_machine_put(mach);
 	return error;
 }
+#endif // 0
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static int
 nvmm_ctl_mach_info(struct nvmm_owner *owner, struct nvmm_ioc_ctl *args)
 {
@@ -950,6 +966,7 @@ nvmm_ctl(struct nvmm_owner *owner, struct nvmm_ioc_ctl *args)
 		return EINVAL;
 	}
 }
+#endif // 0
 
 /* -------------------------------------------------------------------------- */
 
@@ -1011,7 +1028,7 @@ nvmm_fini(void)
 int
 nvmm_ioctl(struct nvmm_owner *owner, unsigned long cmd, void *data)
 {
-	switch (cmd) {
+/*	switch (cmd) {
 	case NVMM_IOC_CAPABILITY:
 		return nvmm_capability(owner, data);
 	case NVMM_IOC_MACHINE_CREATE:
@@ -1046,5 +1063,6 @@ nvmm_ioctl(struct nvmm_owner *owner, unsigned long cmd, void *data)
 		return nvmm_ctl(owner, data);
 	default:
 		return EINVAL;
-	}
+	}*/
+	return EINVAL;
 }

--- a/src/add-ons/kernel/drivers/nvmm/nvmm.h
+++ b/src/add-ons/kernel/drivers/nvmm/nvmm.h
@@ -36,6 +36,10 @@
 #include <stdbool.h>
 #endif
 
+#if defined(__HAIKU__)
+#include <stdint.h>
+#endif
+
 typedef uint64_t	gpaddr_t;
 typedef uint64_t	gvaddr_t;
 
@@ -45,13 +49,17 @@ typedef uint32_t	nvmm_cpuid_t;
 #undef CTASSERT
 #define CTASSERT(x)		NVMM_CTASSERT(x, __LINE__)
 #define NVMM_CTASSERT(x, y)	NVMM__CTASSERT(x, y)
-#define NVMM__CTASSERT(x, y)	typedef char __assert ## y[(x) ? 1 : -1] __unused
+//#define NVMM__CTASSERT(x, y)	typedef char __assert ## y[(x) ? 1 : -1] __unused
+//temporary
+#define NVMM__CTASSERT(x, y)
 
 #if defined(__x86_64__)
 #if defined(__NetBSD__)
 #include <dev/nvmm/x86/nvmm_x86.h>
 #elif defined(__DragonFly__)
 #include <dev/virtual/nvmm/x86/nvmm_x86.h>
+#elif defined(__HAIKU__)
+//#include "x86/nvmm_x86.h"
 #endif
 #endif /* __x86_64__ */
 
@@ -64,7 +72,9 @@ struct nvmm_capability {
 	uint32_t max_machines;
 	uint32_t max_vcpus;
 	uint64_t max_ram;
+	#ifndef __HAIKU__ // We only support a toy x86 backend so far
 	struct nvmm_cap_md arch;
+	#endif
 };
 
 /* Machine configuration slots. */
@@ -84,11 +94,15 @@ struct nvmm_comm_page {
 	uint64_t state_wanted;
 	uint64_t state_cached;
 	uint64_t state_commit;
+	#ifndef __HAIKU__ // Not supported yet
 	struct nvmm_vcpu_state state;
+	#endif
 
 	/* Event. */
 	bool event_commit;
+	#ifndef __HAIKU__ // Not supported yet
 	struct nvmm_vcpu_event event;
+	#endif
 };
 
 #endif

--- a/src/add-ons/kernel/drivers/nvmm/nvmm_haiku.cpp
+++ b/src/add-ons/kernel/drivers/nvmm/nvmm_haiku.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Daniel Martin, dalmemail@gmail.com
+ * All rights reserved. Distributed under the terms of the MIT License.
+ */
+
+
+#include <Drivers.h>
+
+#include "nvmm.h"
+#include "nvmm_internal.h"
+#include "nvmm_os.h"
+#include "x86/nvmm_x86.h"
+
+#include <OS.h>
+
+
+void x86_get_cpuid(uint32_t eax, cpuid_desc_t *descriptors)
+{
+	cpuid_info info;
+	if (get_cpuid(&info, eax, 0) != B_OK) {
+		descriptors->eax = 0;
+		descriptors->ebx = 0;
+		descriptors->ecx = 0;
+		descriptors->edx = 0;
+	}
+	else {
+		descriptors->eax = info.regs.eax;
+		descriptors->ebx = info.regs.ebx;
+		descriptors->ecx = info.regs.ecx;
+		descriptors->edx = info.regs.edx;
+	}
+}
+
+
+int32 api_version = B_CUR_DRIVER_API_VERSION;
+
+
+status_t
+init_hardware(void)
+{
+	if (nvmm_ident() == NULL) {
+		TRACE_ALWAYS("nvmm: cpu not supported\n");
+		return B_ERROR;
+	}
+	return B_OK;
+}
+
+
+const char**
+publish_devices(void)
+{
+	TRACE_ALWAYS("nvmm: publish_devices\n");
+	return NULL;
+}
+
+
+device_hooks*
+find_device(const char* name)
+{
+	TRACE_ALWAYS("nvmm: find_device\n");
+	return NULL;
+}
+
+
+status_t
+init_driver(void)
+{
+	TRACE_ALWAYS("nvmm: init_driver\n");
+	return B_OK;
+}
+
+
+void
+uninit_driver(void)
+{
+	TRACE_ALWAYS("nvmm: uninit_driver\n");
+}

--- a/src/add-ons/kernel/drivers/nvmm/nvmm_internal.h
+++ b/src/add-ons/kernel/drivers/nvmm/nvmm_internal.h
@@ -29,6 +29,12 @@
 #ifndef _NVMM_INTERNAL_H_
 #define _NVMM_INTERNAL_H_
 
+#if defined(__HAIKU__)
+#ifdef _KERNEL_MODE
+#define _KERNEL
+#endif
+#endif
+
 #ifndef _KERNEL
 #error "This file should not be included by userland programs."
 #endif
@@ -43,6 +49,8 @@
 #define NVMM_MAX_RAM		(128ULL * (1 << 30))
 #elif defined(__DragonFly__)
 #define NVMM_MAX_RAM		(127ULL * 1024ULL * (1 << 30))
+#elif defined(__HAIKU__)
+/* Empty for now */
 #else
 #error "OS dependency for NVMM_MAX_RAM required"
 #endif
@@ -74,7 +82,9 @@ struct nvmm_hmapping {
 	bool present;
 	uintptr_t hva;
 	size_t size;
+	#ifndef __HAIKU__ // Not supported yet by our port
 	os_vmobj_t *vmobj;
+	#endif
 };
 
 struct nvmm_machine {
@@ -85,7 +95,9 @@ struct nvmm_machine {
 	os_rwl_t lock;
 
 	/* Comm */
+	#ifndef __HAIKU__ // Not supported yet by our port
 	os_vmobj_t *commvmobj;
+	#endif
 
 	/* Kernel */
 	struct vmspace *vm;
@@ -133,7 +145,9 @@ struct nvmm_impl {
 };
 
 #if defined(__x86_64__)
+#ifndef __HAIKU__
 extern const struct nvmm_impl nvmm_x86_svm;
+#endif
 extern const struct nvmm_impl nvmm_x86_vmx;
 #endif
 
@@ -141,10 +155,16 @@ extern struct nvmm_owner nvmm_root_owner;
 extern volatile unsigned int nmachines;
 extern const struct nvmm_impl *nvmm_impl;
 
+#if defined(__HAIKU__) && defined(__cplusplus)
+extern "C" {
+#endif
 const struct nvmm_impl *nvmm_ident(void);
 int	nvmm_init(void);
 void	nvmm_fini(void);
 int	nvmm_ioctl(struct nvmm_owner *, unsigned long, void *);
 void	nvmm_kill_machines(struct nvmm_owner *);
+#if defined(__HAIKU__) && defined(__cplusplus)
+}
+#endif
 
 #endif /* _NVMM_INTERNAL_H_ */

--- a/src/add-ons/kernel/drivers/nvmm/nvmm_internal.h
+++ b/src/add-ons/kernel/drivers/nvmm/nvmm_internal.h
@@ -145,9 +145,7 @@ struct nvmm_impl {
 };
 
 #if defined(__x86_64__)
-#ifndef __HAIKU__
 extern const struct nvmm_impl nvmm_x86_svm;
-#endif
 extern const struct nvmm_impl nvmm_x86_vmx;
 #endif
 

--- a/src/add-ons/kernel/drivers/nvmm/nvmm_ioctl.h
+++ b/src/add-ons/kernel/drivers/nvmm/nvmm_ioctl.h
@@ -29,12 +29,16 @@
 #ifndef _NVMM_IOCTL_H_
 #define _NVMM_IOCTL_H_
 
+#ifndef __HAIKU__
 #include <sys/ioccom.h>
+#endif
 
 #if defined(__NetBSD__)
 #include <dev/nvmm/nvmm.h>
 #elif defined(__DragonFly__)
 #include <dev/virtual/nvmm/nvmm.h>
+#elif defined(__HAIKU__)
+#include "nvmm.h"
 #else
 #error "Unsupported OS."
 #endif
@@ -95,7 +99,9 @@ struct nvmm_ioc_vcpu_run {
 	nvmm_machid_t machid;
 	nvmm_cpuid_t cpuid;
 	/* output */
+	#ifndef __HAIKU__ // Not supported by our port yet
 	struct nvmm_vcpu_exit exit;
+	#endif
 };
 
 struct nvmm_ioc_hva_map {
@@ -144,6 +150,28 @@ struct nvmm_ioc_ctl {
 	size_t size;
 };
 
+#if defined(__HAIKU__)
+// These ioctl opcodes are not unique in Haiku
+// (that's what the _IOXX() macros try to achive)
+enum {
+	NVMM_IOC_CAPABILITY = B_DEVICE_OP_CODES_END + 1,
+	NVMM_IOC_MACHINE_CREATE,
+	NVMM_IOC_MACHINE_DESTROY,
+	NVMM_IOC_MACHINE_CONFIGURE,
+	NVMM_IOC_VCPU_CREATE,
+	NVMM_IOC_VCPU_DESTROY,
+	NVMM_IOC_VCPU_CONFIGURE,
+	NVMM_IOC_VCPU_SETSTATE,
+	NVMM_IOC_VCPU_GETSTATE,
+	NVMM_IOC_VCPU_INJECT,
+	NVMM_IOC_VCPU_RUN,
+	NVMM_IOC_GPA_MAP,
+	NVMM_IOC_GPA_UNMAP,
+	NVMM_IOC_HVA_MAP,
+	NVMM_IOC_HVA_UNMAP,
+	NVMM_IOC_CTL
+};
+#else
 #define NVMM_IOC_CAPABILITY		_IOR ('N',  0, struct nvmm_ioc_capability)
 #define NVMM_IOC_MACHINE_CREATE		_IOWR('N',  1, struct nvmm_ioc_machine_create)
 #define NVMM_IOC_MACHINE_DESTROY	_IOW ('N',  2, struct nvmm_ioc_machine_destroy)
@@ -160,5 +188,6 @@ struct nvmm_ioc_ctl {
 #define NVMM_IOC_HVA_MAP		_IOW ('N', 13, struct nvmm_ioc_hva_map)
 #define NVMM_IOC_HVA_UNMAP		_IOW ('N', 14, struct nvmm_ioc_hva_unmap)
 #define NVMM_IOC_CTL			_IOW ('N', 20, struct nvmm_ioc_ctl)
+#endif
 
 #endif /* _NVMM_IOCTL_H_ */

--- a/src/add-ons/kernel/drivers/nvmm/x86/nvmm_x86.h
+++ b/src/add-ons/kernel/drivers/nvmm/x86/nvmm_x86.h
@@ -221,6 +221,7 @@ struct nvmm_cap_md {
 
 #ifndef ASM_NVMM
 
+#ifndef __HAIKU__
 #include <sys/types.h>
 #include <sys/bitops.h>
 #if defined(__DragonFly__)
@@ -230,7 +231,8 @@ struct nvmm_cap_md {
 #undef  __BITS
 #define __BITS(__m, __n)	__BITS64(__m, __n)
 #endif /* __x86_64__ */
-#endif
+#endif /* __HAIKU__ */
+#endif /* ASM_NVMM */
 
 /* Segment state. */
 struct nvmm_x64_state_seg {
@@ -657,7 +659,7 @@ struct nvmm_vcpu_conf_tpr {
  * Register defines. We mainly rely on the already-existing OS definitions.
  */
 
-#if defined(__DragonFly__)
+#if defined(__DragonFly__) || defined(__HAIKU__)
 
 #define XCR0_X87		CPU_XFEATURE_X87	/* 0x00000001 */
 #define XCR0_SSE		CPU_XFEATURE_SSE	/* 0x00000002 */
@@ -745,6 +747,14 @@ typedef struct {
 #elif defined(__DragonFly__)
 #define x86_get_cpuid(l, d)	do_cpuid(l, (uint32_t *)d)
 #define x86_get_cpuid2(l, c, d)	cpuid_count(l, c, (uint32_t *)d)
+#elif defined(__HAIKU__)
+#ifdef __cplusplus
+extern "C" {
+#endif
+void x86_get_cpuid(uint32_t eax, cpuid_desc_t *descriptors);
+#ifdef __cplusplus
+}
+#endif
 #endif
 
 /* Control registers. */

--- a/src/add-ons/kernel/drivers/nvmm/x86/nvmm_x86_svm.c
+++ b/src/add-ons/kernel/drivers/nvmm/x86/nvmm_x86_svm.c
@@ -26,15 +26,18 @@
  * SUCH DAMAGE.
  */
 
+#ifndef __HAIKU__
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/kernel.h>
 #include <sys/mman.h>
+#endif
 
 #include "../nvmm.h"
 #include "../nvmm_internal.h"
 #include "nvmm_x86.h"
 
+#if 0
 void svm_vmrun(paddr_t, uint64_t *);
 
 static inline void
@@ -48,6 +51,7 @@ svm_stgi(void)
 {
 	__asm volatile ("stgi" ::: "memory");
 }
+#endif
 
 #define	MSR_VM_HSAVE_PA	0xC0010117
 
@@ -234,6 +238,7 @@ svm_stgi(void)
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 struct vmcb_ctrl {
 	uint32_t intercept_cr;
 #define VMCB_CTRL_INTERCEPT_RCR(x)	__BIT( 0 + x)
@@ -472,9 +477,11 @@ struct vmcb {
 
 CTASSERT(sizeof(struct vmcb) == PAGE_SIZE);
 CTASSERT(offsetof(struct vmcb, state) == 0x400);
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static void svm_vcpu_state_provide(struct nvmm_cpu *, uint64_t);
 static void svm_vcpu_state_commit(struct nvmm_cpu *);
 
@@ -499,8 +506,10 @@ static struct svm_hsave hsave[OS_MAXCPUS];
 static uint8_t *svm_asidmap __read_mostly;
 static uint32_t svm_maxasid __read_mostly;
 static os_mtx_t svm_asidlock __cacheline_aligned;
+#endif // 0
 
 static bool svm_decode_assist __read_mostly;
+#if 0
 static uint32_t svm_ctrl_tlb_flush __read_mostly;
 
 #define SVM_XCR0_MASK_DEFAULT	(XCR0_X87|XCR0_SSE)
@@ -527,8 +536,10 @@ static uint64_t svm_xcr0_mask __read_mostly;
 #define CR4_TLB_FLUSH \
 	(CR4_PSE|CR4_PAE|CR4_PGE|CR4_PCIDE|CR4_SMEP)
 
+#endif
 /* -------------------------------------------------------------------------- */
 
+#if 0
 struct svm_machdata {
 	volatile uint64_t mach_htlb_gen;
 };
@@ -1361,8 +1372,10 @@ svm_exit_invalid(struct nvmm_vcpu_exit *exit, uint64_t code)
 	exit->reason = NVMM_VCPU_EXIT_INVALID;
 }
 
+#endif // 0
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static void
 svm_vcpu_guest_fpu_enter(struct nvmm_cpu *vcpu)
 {
@@ -1454,9 +1467,11 @@ svm_vcpu_guest_misc_leave(struct nvmm_cpu *vcpu)
 	wrmsr(MSR_FSBASE, cpudata->hstate.fsbase);
 	wrmsr(MSR_KERNELGSBASE, cpudata->hstate.kernelgsbase);
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static inline void
 svm_gtlb_catchup(struct nvmm_cpu *vcpu, int hcpu)
 {
@@ -1721,9 +1736,11 @@ svm_vcpu_run(struct nvmm_machine *mach, struct nvmm_cpu *vcpu,
 
 	return error;
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 #define SVM_MSRBM_READ	__BIT(0)
 #define SVM_MSRBM_WRITE	__BIT(1)
 
@@ -2099,9 +2116,11 @@ svm_vcpu_state_commit(struct nvmm_cpu *vcpu)
 	vcpu->comm->state_commit = 0;
 	svm_vcpu_setstate(vcpu);
 }
+#endif // 0
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static void
 svm_asid_alloc(struct nvmm_cpu *vcpu)
 {
@@ -2349,9 +2368,11 @@ svm_vcpu_destroy(struct nvmm_machine *mach, struct nvmm_cpu *vcpu)
 
 	os_pagemem_free(cpudata, sizeof(*cpudata));
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static int
 svm_vcpu_configure_cpuid(struct svm_cpudata *cpudata, void *data)
 {
@@ -2419,9 +2440,11 @@ svm_vcpu_configure(struct nvmm_cpu *vcpu, uint64_t op, void *data)
 		return EINVAL;
 	}
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 #ifdef __NetBSD__
 static void
 svm_tlb_flush(struct pmap *pm)
@@ -2472,6 +2495,7 @@ svm_machine_configure(struct nvmm_machine *mach, uint64_t op, void *data)
 {
 	panic("%s: impossible", __func__);
 }
+#endif // 0
 
 /* -------------------------------------------------------------------------- */
 
@@ -2533,6 +2557,7 @@ svm_ident(void)
 	return true;
 }
 
+#if 0
 static void
 svm_init_asid(uint32_t maxasid)
 {
@@ -2666,10 +2691,11 @@ svm_capability(struct nvmm_capability *cap)
 	cap->arch.mxcsr_mask = x86_fpu_mxcsr_mask;
 	cap->arch.conf_cpuid_maxops = SVM_NCPUIDS;
 }
+#endif
 
 const struct nvmm_impl nvmm_x86_svm = {
 	.name = "x86-svm",
-	.ident = svm_ident,
+	.ident = svm_ident/*,
 	.init = svm_init,
 	.fini = svm_fini,
 	.capability = svm_capability,
@@ -2687,5 +2713,5 @@ const struct nvmm_impl nvmm_x86_svm = {
 	.vcpu_setstate = svm_vcpu_setstate,
 	.vcpu_getstate = svm_vcpu_getstate,
 	.vcpu_inject = svm_vcpu_inject,
-	.vcpu_run = svm_vcpu_run
+	.vcpu_run = svm_vcpu_run*/
 };

--- a/src/add-ons/kernel/drivers/nvmm/x86/nvmm_x86_vmx.c
+++ b/src/add-ons/kernel/drivers/nvmm/x86/nvmm_x86_vmx.c
@@ -26,15 +26,18 @@
  * SUCH DAMAGE.
  */
 
+#ifndef __HAIKU__
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/kernel.h>
 #include <sys/mman.h>
+#endif
 
 #include "../nvmm.h"
 #include "../nvmm_internal.h"
 #include "nvmm_x86.h"
 
+#if 0
 int vmx_vmlaunch(uint64_t *gprs);
 int vmx_vmresume(uint64_t *gprs);
 void vmx_resume_rip(void);
@@ -183,6 +186,7 @@ vmx_sti(void)
 {
 	__asm volatile ("sti" ::: "memory");
 }
+#endif
 
 #define MSR_IA32_FEATURE_CONTROL	0x003A
 #define		IA32_FEATURE_CONTROL_LOCK	__BIT(0)
@@ -590,13 +594,16 @@ vmx_sti(void)
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static void vmx_vcpu_state_provide(struct nvmm_cpu *, uint64_t);
 static void vmx_vcpu_state_commit(struct nvmm_cpu *);
+#endif
 
 /*
  * These host values are static, they do not change at runtime and are the same
  * on all CPUs. We save them here because they are not saved in the VMCS.
  */
+#if 0
 static struct {
 	uint64_t xcr0;
 	uint64_t star;
@@ -604,6 +611,7 @@ static struct {
 	uint64_t cstar;
 	uint64_t sfmask;
 } vmx_global_hstate __cacheline_aligned;
+#endif
 
 #define VMX_MSRLIST_STAR		0
 #define VMX_MSRLIST_LSTAR		1
@@ -616,6 +624,7 @@ static struct {
 /* On entry, we may do +1 to include L1DFLUSH. */
 static size_t vmx_msrlist_entry_nmsr __read_mostly = VMX_MSRLIST_EXIT_NMSR;
 
+#if 0
 struct vmxon {
 	uint32_t ident;
 #define VMXON_IDENT_REVISION	__BITS(30,0)
@@ -650,9 +659,10 @@ struct msr_entry {
 } __packed;
 
 #define VPID_MAX	0xFFFF
+#endif // 0
 
 /* Make sure we never run out of VPIDs. */
-CTASSERT(VPID_MAX-1 >= NVMM_MAX_MACHINES * NVMM_MAX_VCPUS);
+/*CTASSERT(VPID_MAX-1 >= NVMM_MAX_MACHINES * NVMM_MAX_VCPUS);*/
 
 static uint64_t vmx_tlb_flush_op __read_mostly;
 static uint64_t vmx_ept_flush_op __read_mostly;
@@ -773,6 +783,7 @@ static uint64_t vmx_xcr0_mask __read_mostly;
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 struct vmx_machdata {
 	volatile uint64_t mach_htlb_gen;
 };
@@ -903,9 +914,11 @@ static const struct {
 		VMCS_GUEST_TR_BASE
 	}
 };
+#endif // 0
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static uint64_t
 vmx_get_revision(void)
 {
@@ -1008,9 +1021,11 @@ vmx_vmcs_destroy(struct nvmm_cpu *vcpu)
 	vmx_vmclear(&cpudata->vmcs_pa);
 	os_preempt_enable();
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static void
 vmx_event_waitexit_enable(struct nvmm_cpu *vcpu, bool nmi)
 {
@@ -1586,6 +1601,7 @@ vmx_exit_hlt(struct nvmm_machine *mach, struct nvmm_cpu *vcpu,
 #define VMX_QUAL_CR_LMSW_OPMEM	__BIT(6)
 #define VMX_QUAL_CR_GPR		__BITS(11,8)
 #define VMX_QUAL_CR_LMSW_SRC	__BIT(31,16)
+#endif // 0
 
 static inline int
 vmx_check_cr(uint64_t crval, uint64_t fixed0, uint64_t fixed1)
@@ -1601,6 +1617,7 @@ vmx_check_cr(uint64_t crval, uint64_t fixed0, uint64_t fixed1)
 	return 0;
 }
 
+#if 0
 static int
 vmx_inkernel_handle_cr0(struct nvmm_machine *mach, struct nvmm_cpu *vcpu,
     uint64_t qual)
@@ -2040,9 +2057,11 @@ vmx_exit_epf(struct nvmm_machine *mach, struct nvmm_cpu *vcpu,
 	    NVMM_X64_STATE_GPRS | NVMM_X64_STATE_SEGS |
 	    NVMM_X64_STATE_CRS | NVMM_X64_STATE_MSRS);
 }
+#endif // 0
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static void
 vmx_vcpu_guest_fpu_enter(struct nvmm_cpu *vcpu)
 {
@@ -2140,9 +2159,11 @@ vmx_vcpu_guest_misc_leave(struct nvmm_cpu *vcpu)
 	/* Restore the percpu host state. */
 	wrmsr(MSR_KERNELGSBASE, cpudata->hstate.kernelgsbase);
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 #define VMX_INVVPID_ADDRESS		0
 #define VMX_INVVPID_CONTEXT		1
 #define VMX_INVVPID_ALL			2
@@ -2461,9 +2482,11 @@ vmx_vcpu_run(struct nvmm_machine *mach, struct nvmm_cpu *vcpu,
 
 	return error;
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static void
 vmx_vcpu_msr_allow(uint8_t *bitmap, uint64_t msr, bool read, bool write)
 {
@@ -2871,9 +2894,11 @@ vmx_vcpu_state_commit(struct nvmm_cpu *vcpu)
 	vcpu->comm->state_commit = 0;
 	vmx_vcpu_setstate(vcpu);
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static void
 vmx_asid_alloc(struct nvmm_cpu *vcpu)
 {
@@ -3109,9 +3134,11 @@ vmx_vcpu_destroy(struct nvmm_machine *mach, struct nvmm_cpu *vcpu)
 	    1);
 	os_pagemem_free(cpudata, sizeof(*cpudata));
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 static int
 vmx_vcpu_configure_cpuid(struct vmx_cpudata *cpudata, void *data)
 {
@@ -3190,9 +3217,11 @@ vmx_vcpu_configure(struct nvmm_cpu *vcpu, uint64_t op, void *data)
 		return EINVAL;
 	}
 }
+#endif
 
 /* -------------------------------------------------------------------------- */
 
+#if 0
 #ifdef __NetBSD__
 static void
 vmx_tlb_flush(struct pmap *pm)
@@ -3244,6 +3273,7 @@ vmx_machine_configure(struct nvmm_machine *mach, uint64_t op, void *data)
 {
 	panic("%s: impossible", __func__);
 }
+#endif // 0
 
 /* -------------------------------------------------------------------------- */
 
@@ -3455,6 +3485,7 @@ vmx_ident(void)
 	return true;
 }
 
+#if 0
 static void
 vmx_init_asid(uint32_t maxasid)
 {
@@ -3502,6 +3533,7 @@ OS_IPI_FUNC(vmx_change_cpu)
 		vmx_vmxon(&vmxoncpu[os_curcpu_number()].pa);
 	}
 }
+#endif
 
 static void
 vmx_init_l1tf(void)
@@ -3530,6 +3562,7 @@ vmx_init_l1tf(void)
 	}
 }
 
+#if 0
 static void
 vmx_init(void)
 {
@@ -3603,7 +3636,9 @@ vmx_init(void)
 
 	os_ipi_broadcast(vmx_change_cpu, (void *)true);
 }
+#endif
 
+#if 0
 static void
 vmx_fini_asid(void)
 {
@@ -3614,7 +3649,9 @@ vmx_fini_asid(void)
 
 	os_mtx_destroy(&vmx_asidlock);
 }
+#endif
 
+#if 0
 static void
 vmx_fini(void)
 {
@@ -3629,7 +3666,9 @@ vmx_fini(void)
 
 	vmx_fini_asid();
 }
+#endif
 
+#if 0
 static void
 vmx_capability(struct nvmm_capability *cap)
 {
@@ -3641,10 +3680,11 @@ vmx_capability(struct nvmm_capability *cap)
 	cap->arch.mxcsr_mask = x86_fpu_mxcsr_mask;
 	cap->arch.conf_cpuid_maxops = VMX_NCPUIDS;
 }
+#endif
 
 const struct nvmm_impl nvmm_x86_vmx = {
 	.name = "x86-vmx",
-	.ident = vmx_ident,
+	.ident = vmx_ident/*,
 	.init = vmx_init,
 	.fini = vmx_fini,
 	.capability = vmx_capability,
@@ -3662,5 +3702,5 @@ const struct nvmm_impl nvmm_x86_vmx = {
 	.vcpu_setstate = vmx_vcpu_setstate,
 	.vcpu_getstate = vmx_vcpu_getstate,
 	.vcpu_inject = vmx_vcpu_inject,
-	.vcpu_run = vmx_vcpu_run
+	.vcpu_run = vmx_vcpu_run*/
 };


### PR DESCRIPTION
In the end I needed to use DragonFly's specialreg.h since the FreeBSD version has some extra definitions that are already defined at NVMM's source code and that was problematic.

The driver itself so far does exactly the same as the stub driver I submitted for the GSoC proposal, but now we have the full NVMM code imported and we're compiling the C parts as C instead of compiling everything as C++. It supports SVM too.